### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/blogging/admin.py
+++ b/blogging/admin.py
@@ -49,9 +49,9 @@ class PostAdmin(admin.ModelAdmin):
         """
         field = super(PostAdmin, self).formfield_for_manytomany(db_field, request, **kwargs)
         field.queryset = field.queryset.order_by('site__domain')
-        field.label_from_instance = lambda obj: "%(site)s - %(name)s" % {
+        field.label_from_instance = lambda obj: "{site!s} - {name!s}".format(**{
             'site': obj.site, 'name': obj.name
-        }
+        })
         return field
 
 admin.site.register(Picture, PictureAdmin)

--- a/blogging/templatetags/categories.py
+++ b/blogging/templatetags/categories.py
@@ -26,7 +26,7 @@ def categories(parser, token):
     """
     tokens = token.split_contents()
     if len(tokens) is not 3 and token[0] == 'categories' and token[0] == 'as':
-        raise template.TemplateSyntaxError("%r tag must be used with %s" % (tokens[0], "{% categories as categories %}"))
+        raise template.TemplateSyntaxError("{0!r} tag must be used with {1!s}".format(tokens[0], "{% categories as categories %}"))
     var_name = tokens[2]
     return CategoriesNode(var_name)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jibaku:blogging?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:jibaku:blogging?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)