### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/blogging/actions.py
+++ b/blogging/actions.py
@@ -58,7 +58,7 @@ def make_post_type_action(key, name):
 
     action = action_f
     action.__name__ = func_name
-    return (func_name, (action, func_name, "define selected as %s" % name))
+    return (func_name, (action, func_name, "define selected as {0!s}".format(name)))
 
 
 # Category Actions


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jibaku:blogging?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:jibaku:blogging?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)